### PR TITLE
Fix table alignment in WideGPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you enjoy my projects, you can buy me a coffee!
 
 ### Technical
 
-This plugin changes appearance only on chatgpt.com. See [manifest.json](manifest.json) for reference. 
+This plugin changes appearance only on chatgpt.com. See [manifest.json](manifest.json) for reference.
 
 ### Local Installation Steps for debugging purposes
 

--- a/content.js
+++ b/content.js
@@ -77,6 +77,16 @@ const adjustMaxWidth = (width = 100) => {
                 --thread-content-max-width: ${width}% !important;
             }
         }
+        /* Override table container margins added by ChatGPT */
+        div[class^='_tableContainer'] {
+            --thread-content-width: unset !important;
+        }
+
+        /* Ensure table wrapper matches selected width */
+        div[class^='_tableWrapper'] {
+            min-width: fit-content !important;
+            max-width: ${width}% !important;
+        }
     `;
     attachOrUpdateStyleRule(css);
 };


### PR DESCRIPTION
## Summary
- remove note about table centering from README
- tweak table container override to use unset
- keep table wrappers within selected width

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684451e3d13483289089f0ba5ae52ae1